### PR TITLE
feat: 新增 NL2SQL Agent 编排与修复回路

### DIFF
--- a/src/main/java/com/datanote/controller/AiAssistController.java
+++ b/src/main/java/com/datanote/controller/AiAssistController.java
@@ -60,20 +60,13 @@ public class AiAssistController {
      */
     @Operation(summary = "自然语言转SQL")
     @PostMapping("/nl2sql")
-    public R<Map<String, String>> nl2sql(@RequestBody AiNl2SqlRequest body) {
+    public R<Map<String, Object>> nl2sql(@RequestBody AiNl2SqlRequest body) {
         String question = body.getQuestion();
         String tableSchema = body.getTableSchema() != null ? body.getTableSchema() : "";
         if (question == null || question.trim().isEmpty()) {
             return R.fail("问题不能为空");
         }
-        String reply = aiAssistService.nl2sql(question, tableSchema);
-        Map<String, String> result = new HashMap<>();
-        result.put("reply", reply);
-        // 提取 SQL 代码块
-        String sql = extractSqlBlock(reply);
-        if (sql != null) {
-            result.put("sql", sql);
-        }
+        Map<String, Object> result = aiAssistService.nl2sqlAgent(question, tableSchema);
         return R.ok(result);
     }
 
@@ -251,14 +244,4 @@ public class AiAssistController {
         return R.ok(result);
     }
 
-    private String extractSqlBlock(String text) {
-        int start = text.indexOf("```sql");
-        if (start == -1) start = text.indexOf("```SQL");
-        if (start == -1) return null;
-        start = text.indexOf('\n', start);
-        if (start == -1) return null;
-        int end = text.indexOf("```", start + 1);
-        if (end == -1) return null;
-        return text.substring(start + 1, end).trim();
-    }
 }

--- a/src/main/java/com/datanote/service/AiAssistService.java
+++ b/src/main/java/com/datanote/service/AiAssistService.java
@@ -1,5 +1,6 @@
 package com.datanote.service;
 
+import com.datanote.config.HiveConfig;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.datanote.mapper.DnSystemConfigMapper;
 import com.datanote.model.DnSystemConfig;
@@ -16,7 +17,11 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.*;
+import java.util.regex.Pattern;
 
 /**
  * AI 辅助开发服务 — 调用 Claude API 实现 NL2SQL、SQL 解释等智能功能
@@ -28,6 +33,7 @@ public class AiAssistService {
 
     private final ObjectMapper objectMapper;
     private final DnSystemConfigMapper systemConfigMapper;
+    private final HiveConfig hiveConfig;
 
     @Value("${datanote.ai.api-key:}")
     private String envApiKey;
@@ -92,6 +98,19 @@ public class AiAssistService {
             "- 默认使用 HiveSQL 语法（支持分区表、ORC 格式等）\n" +
             "- SQL 语句用 ```sql 代码块包裹\n" +
             "- 回答简洁专业，中文回复";
+
+    private static final int NL2SQL_SCHEMA_TOP_TABLES = 5;
+    private static final int NL2SQL_SCHEMA_MAX_COLS = 12;
+    private static final int NL2SQL_MAX_REPAIR_ROUNDS = 2;
+    private static final int NL2SQL_DEFAULT_LIMIT = 100;
+    private static final Set<String> HIVE_SYS_DBS = new HashSet<String>(Arrays.asList(
+            "default", "information_schema", "sys"
+    ));
+    private static final Pattern DANGEROUS_SQL_PATTERN = Pattern.compile(
+            "\\b(insert|update|delete|drop|alter|truncate|create|grant|revoke|merge)\\b",
+            Pattern.CASE_INSENSITIVE
+    );
+    private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("^[a-zA-Z0-9_]+$");
 
     /**
      * 调用 Claude API 进行对话
@@ -172,6 +191,102 @@ public class AiAssistService {
     }
 
     /**
+     * NL2SQL Agent：Schema 召回 + SQL 生成 + 守卫 + Dry-run + 最多2轮修复
+     */
+    public Map<String, Object> nl2sqlAgent(String question, String tableSchema) {
+        Map<String, Object> result = new HashMap<String, Object>();
+        List<Map<String, String>> trace = new ArrayList<Map<String, String>>();
+        result.put("trace", trace);
+
+        String safeQuestion = question == null ? "" : question.trim();
+        if (safeQuestion.isEmpty()) {
+            result.put("reply", "问题不能为空");
+            result.put("status", "failed");
+            result.put("attempts", 0);
+            result.put("error", "问题不能为空");
+            return result;
+        }
+
+        String schemaContext = buildSchemaContext(safeQuestion, tableSchema);
+        String prompt = "请根据以下需求生成 Hive SQL。严格要求：\n"
+                + "1) 只允许 SELECT 语句\n"
+                + "2) 仅返回 ```sql 代码块\n"
+                + "3) 不要输出解释文字\n\n"
+                + "需求：\n" + safeQuestion;
+        String aiReply = chat(prompt, schemaContext);
+        String sqlCandidate = extractSqlBlock(aiReply);
+        if (sqlCandidate == null || sqlCandidate.trim().isEmpty()) {
+            sqlCandidate = aiReply;
+        }
+
+        String lastError = null;
+        String currentSql = sqlCandidate;
+        String lastReply = aiReply;
+
+        for (int round = 0; round <= NL2SQL_MAX_REPAIR_ROUNDS; round++) {
+            int attempts = round + 1;
+            Map<String, String> traceItem = new LinkedHashMap<String, String>();
+            traceItem.put("attempt", String.valueOf(attempts));
+            traceItem.put("rawSql", safeSnippet(currentSql));
+
+            String guardedSql;
+            try {
+                guardedSql = ensureSafeSelectSql(currentSql);
+                traceItem.put("guardedSql", safeSnippet(guardedSql));
+            } catch (IllegalArgumentException ex) {
+                lastError = ex.getMessage();
+                traceItem.put("error", lastError);
+                trace.add(traceItem);
+                result.put("reply", lastReply);
+                result.put("status", "failed");
+                result.put("attempts", attempts);
+                result.put("error", lastError);
+                result.put("sql", null);
+                return result;
+            }
+
+            String dryRunError = dryRunSql(guardedSql);
+            if (dryRunError == null) {
+                traceItem.put("dryRun", "ok");
+                trace.add(traceItem);
+                result.put("reply", lastReply);
+                result.put("status", "success");
+                result.put("attempts", attempts);
+                result.put("error", "");
+                result.put("sql", guardedSql);
+                return result;
+            }
+
+            traceItem.put("dryRun", "failed");
+            traceItem.put("error", dryRunError);
+            trace.add(traceItem);
+            lastError = dryRunError;
+
+            if (round >= NL2SQL_MAX_REPAIR_ROUNDS) {
+                break;
+            }
+
+            String repairPrompt = "下面 SQL 在 Hive 执行失败，请修复为可执行的单条 SELECT 语句。\n"
+                    + "严格要求：\n"
+                    + "1) 只允许 SELECT\n"
+                    + "2) 仅返回 ```sql 代码块\n"
+                    + "3) 不要解释\n\n"
+                    + "原 SQL：\n```sql\n" + guardedSql + "\n```\n\n"
+                    + "错误信息：\n" + dryRunError;
+            lastReply = chat(repairPrompt, schemaContext);
+            String repaired = extractSqlBlock(lastReply);
+            currentSql = (repaired != null && !repaired.trim().isEmpty()) ? repaired : lastReply;
+        }
+
+        result.put("reply", lastReply);
+        result.put("status", "failed");
+        result.put("attempts", NL2SQL_MAX_REPAIR_ROUNDS + 1);
+        result.put("error", lastError != null ? lastError : "SQL 修复失败");
+        result.put("sql", null);
+        return result;
+    }
+
+    /**
      * SQL 解释
      */
     public String explainSql(String sql) {
@@ -185,6 +300,34 @@ public class AiAssistService {
     public String optimizeSql(String sql) {
         String prompt = "请分析以下 SQL 的性能问题并给出优化建议：\n```sql\n" + sql + "\n```";
         return chat(prompt, null);
+    }
+
+    String ensureSafeSelectSql(String sql) {
+        String cleaned = stripCodeFence(sql);
+        if (cleaned.isEmpty()) {
+            throw new IllegalArgumentException("AI 未返回 SQL");
+        }
+        String compact = cleaned.trim();
+        if (compact.endsWith(";")) {
+            compact = compact.substring(0, compact.length() - 1).trim();
+        }
+        if (compact.contains(";")) {
+            throw new IllegalArgumentException("仅允许单条 SELECT 语句");
+        }
+        if (compact.contains("--") || compact.contains("/*")) {
+            throw new IllegalArgumentException("SQL 含注释或疑似注入内容，已拒绝执行");
+        }
+        String lower = compact.toLowerCase(Locale.ROOT);
+        if (!lower.startsWith("select")) {
+            throw new IllegalArgumentException("仅允许 SELECT 语句");
+        }
+        if (DANGEROUS_SQL_PATTERN.matcher(lower).find()) {
+            throw new IllegalArgumentException("检测到危险关键字，已拒绝执行");
+        }
+        if (!containsLimit(lower)) {
+            compact = compact + " LIMIT " + NL2SQL_DEFAULT_LIMIT;
+        }
+        return compact;
     }
 
     private String callApi(String body, String prov, String key, String base) throws Exception {
@@ -268,6 +411,190 @@ public class AiAssistService {
         } catch (Exception e) {
             log.warn("AI connection test failed: {}", e.getMessage());
             return false;
+        }
+    }
+
+    private String buildSchemaContext(String question, String tableSchema) {
+        String trimmedSchema = tableSchema == null ? "" : tableSchema.trim();
+        if (!trimmedSchema.isEmpty()) {
+            return "以下是可用的表结构信息：\n" + trimmedSchema;
+        }
+        String recalled = recallSchemaContext(question, NL2SQL_SCHEMA_TOP_TABLES, NL2SQL_SCHEMA_MAX_COLS);
+        return recalled.isEmpty() ? "" : ("以下是可用的表结构信息：\n" + recalled);
+    }
+
+    private String recallSchemaContext(String question, int topKTables, int maxColumnsPerTable) {
+        if (!hiveConfig.isHiveAvailable()) {
+            return "";
+        }
+        List<String> tokens = tokenizeQuestion(question);
+        if (tokens.isEmpty()) {
+            return "";
+        }
+
+        List<TableCandidate> candidates = new ArrayList<TableCandidate>();
+        try (Connection conn = hiveConfig.getConnection();
+             Statement dbStmt = conn.createStatement();
+             ResultSet dbRs = dbStmt.executeQuery("SHOW DATABASES")) {
+            while (dbRs.next()) {
+                String db = dbRs.getString(1);
+                if (db == null || HIVE_SYS_DBS.contains(db.toLowerCase(Locale.ROOT))) {
+                    continue;
+                }
+                if (!isSafeIdentifier(db)) {
+                    continue;
+                }
+                try (Statement tbStmt = conn.createStatement();
+                     ResultSet tbRs = tbStmt.executeQuery("SHOW TABLES IN " + db)) {
+                    while (tbRs.next()) {
+                        String table = tbRs.getString(1);
+                        if (table == null || !isSafeIdentifier(table)) {
+                            continue;
+                        }
+                        int score = computeMatchScore(tokens, db, table);
+                        if (score > 0) {
+                            candidates.add(new TableCandidate(db, table, score));
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Schema recall failed: {}", e.getMessage());
+            return "";
+        }
+
+        if (candidates.isEmpty()) {
+            return "";
+        }
+        Collections.sort(candidates, new Comparator<TableCandidate>() {
+            @Override
+            public int compare(TableCandidate a, TableCandidate b) {
+                return Integer.compare(b.score, a.score);
+            }
+        });
+
+        StringBuilder sb = new StringBuilder();
+        int n = Math.min(topKTables, candidates.size());
+        for (int i = 0; i < n; i++) {
+            TableCandidate t = candidates.get(i);
+            sb.append(t.db).append(".").append(t.table).append(":\n");
+            appendColumns(sb, t.db, t.table, maxColumnsPerTable);
+            sb.append("\n");
+        }
+        return sb.toString().trim();
+    }
+
+    private void appendColumns(StringBuilder sb, String db, String table, int maxColumns) {
+        if (!isSafeIdentifier(db) || !isSafeIdentifier(table)) {
+            sb.append("  - <columns unavailable>\n");
+            return;
+        }
+        try (Connection conn = hiveConfig.getConnection();
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("DESCRIBE " + db + "." + table)) {
+            int cnt = 0;
+            while (rs.next() && cnt < maxColumns) {
+                String col = rs.getString(1);
+                if (col == null || col.trim().isEmpty() || col.trim().startsWith("#")) {
+                    break;
+                }
+                String type = rs.getString(2) == null ? "" : rs.getString(2).trim();
+                sb.append("  - ").append(col.trim()).append(" ").append(type).append("\n");
+                cnt++;
+            }
+        } catch (Exception e) {
+            sb.append("  - <columns unavailable>\n");
+        }
+    }
+
+    private int computeMatchScore(List<String> tokens, String db, String table) {
+        String dbLower = db.toLowerCase(Locale.ROOT);
+        String tableLower = table.toLowerCase(Locale.ROOT);
+        int score = 0;
+        for (String token : tokens) {
+            if (dbLower.contains(token)) score += 2;
+            if (tableLower.contains(token)) score += 4;
+        }
+        return score;
+    }
+
+    private List<String> tokenizeQuestion(String question) {
+        if (question == null) return Collections.emptyList();
+        String[] raw = question.toLowerCase(Locale.ROOT).split("[^a-z0-9_\\u4e00-\\u9fa5]+");
+        List<String> tokens = new ArrayList<String>();
+        for (String t : raw) {
+            if (t != null && t.length() >= 2) {
+                tokens.add(t);
+            }
+        }
+        return tokens;
+    }
+
+    private String dryRunSql(String sql) {
+        if (!hiveConfig.isHiveAvailable()) {
+            return null;
+        }
+        try (Connection conn = hiveConfig.getConnection();
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery(sql)) {
+            if (rs != null) {
+                rs.next();
+            }
+            return null;
+        } catch (Exception e) {
+            return e.getMessage() != null ? e.getMessage() : "Dry-run 失败";
+        }
+    }
+
+    private boolean containsLimit(String lowerSql) {
+        return lowerSql.matches("(?s).*\\blimit\\s+\\d+\\b.*");
+    }
+
+    private String stripCodeFence(String text) {
+        if (text == null) {
+            return "";
+        }
+        String trimmed = text.trim();
+        String block = extractSqlBlock(trimmed);
+        if (block != null) {
+            return block.trim();
+        }
+        return trimmed.replace("```sql", "")
+                .replace("```SQL", "")
+                .replace("```", "")
+                .trim();
+    }
+
+    private String extractSqlBlock(String text) {
+        int start = text.indexOf("```sql");
+        if (start == -1) start = text.indexOf("```SQL");
+        if (start == -1) return null;
+        start = text.indexOf('\n', start);
+        if (start == -1) return null;
+        int end = text.indexOf("```", start + 1);
+        if (end == -1) return null;
+        return text.substring(start + 1, end).trim();
+    }
+
+    private String safeSnippet(String text) {
+        if (text == null) return "";
+        String s = text.replace("\n", " ").trim();
+        return s.length() > 300 ? s.substring(0, 300) + "..." : s;
+    }
+
+    private boolean isSafeIdentifier(String name) {
+        return name != null && IDENTIFIER_PATTERN.matcher(name).matches();
+    }
+
+    private static final class TableCandidate {
+        private final String db;
+        private final String table;
+        private final int score;
+
+        private TableCandidate(String db, String table, int score) {
+            this.db = db;
+            this.table = table;
+            this.score = score;
         }
     }
 }

--- a/src/test/java/com/datanote/controller/MetadataControllerTest.java
+++ b/src/test/java/com/datanote/controller/MetadataControllerTest.java
@@ -32,7 +32,7 @@ class MetadataControllerTest {
 
     @Test
     void databases_returnsOk() throws Exception {
-        when(metadataService.getDatabases()).thenReturn(Arrays.asList("datanote", "base_data"));
+        when(dataMapService.getHiveDatabases()).thenReturn(Arrays.asList("datanote", "base_data"));
         R<List<String>> r = controller.databases();
         assertEquals(0, r.getCode());
         assertEquals(2, r.getData().size());
@@ -40,7 +40,7 @@ class MetadataControllerTest {
 
     @Test
     void tables_returnsOk() throws Exception {
-        when(metadataService.getTables("datanote")).thenReturn(Arrays.asList("dn_script", "dn_sync_task"));
+        when(dataMapService.getHiveTables("datanote")).thenReturn(Arrays.asList("dn_script", "dn_sync_task"));
         R<List<String>> r = controller.tables("datanote");
         assertEquals(0, r.getCode());
         assertEquals(2, r.getData().size());
@@ -51,7 +51,7 @@ class MetadataControllerTest {
         ColumnInfo col = new ColumnInfo();
         col.setName("id");
         col.setType("bigint");
-        when(metadataService.getColumns("datanote", "dn_script")).thenReturn(Collections.singletonList(col));
+        when(dataMapService.getHiveColumns("datanote", "dn_script")).thenReturn(Collections.singletonList(col));
         R<List<ColumnInfo>> r = controller.columns("datanote", "dn_script");
         assertEquals(0, r.getCode());
         assertEquals("id", r.getData().get(0).getName());

--- a/src/test/java/com/datanote/service/AiAssistServiceTest.java
+++ b/src/test/java/com/datanote/service/AiAssistServiceTest.java
@@ -1,0 +1,123 @@
+package com.datanote.service;
+
+import com.datanote.config.HiveConfig;
+import com.datanote.mapper.DnSystemConfigMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AiAssistServiceTest {
+
+    @Mock
+    private DnSystemConfigMapper systemConfigMapper;
+    @Mock
+    private HiveConfig hiveConfig;
+
+    private AiAssistService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AiAssistService(new ObjectMapper(), systemConfigMapper, hiveConfig);
+    }
+
+    @Test
+    void ensureSafeSelectSql_appendsLimit_whenMissing() {
+        String sql = service.ensureSafeSelectSql("select id, name from dwd_user");
+        assertEquals("select id, name from dwd_user LIMIT 100", sql);
+    }
+
+    @Test
+    void ensureSafeSelectSql_supportsSqlCodeBlock() {
+        String sql = service.ensureSafeSelectSql("```sql\nselect * from ods_order\n```");
+        assertEquals("select * from ods_order LIMIT 100", sql);
+    }
+
+    @Test
+    void ensureSafeSelectSql_allowsTrailingSemicolon() {
+        String sql = service.ensureSafeSelectSql("select * from ods_order;");
+        assertEquals("select * from ods_order LIMIT 100", sql);
+    }
+
+    @Test
+    void ensureSafeSelectSql_rejectsNonSelect() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.ensureSafeSelectSql("delete from ods_order"));
+        assertTrue(ex.getMessage().contains("仅允许 SELECT"));
+    }
+
+    @Test
+    void ensureSafeSelectSql_rejectsMultiStatement() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.ensureSafeSelectSql("select * from t1; select * from t2"));
+        assertTrue(ex.getMessage().contains("仅允许单条"));
+    }
+
+    @Test
+    void nl2sqlAgent_hiveUnavailable_returnsSuccess() {
+        AiAssistService spy = org.mockito.Mockito.spy(service);
+        when(hiveConfig.isHiveAvailable()).thenReturn(false);
+        doReturn("```sql\nselect id from dwd_user\n```").when(spy).chat(anyString(), anyString());
+
+        Map<String, Object> result = spy.nl2sqlAgent("查询用户ID", "table dwd_user(id string)");
+
+        assertEquals("success", result.get("status"));
+        assertEquals(1, result.get("attempts"));
+        assertEquals("select id from dwd_user LIMIT 100", result.get("sql"));
+    }
+
+    @Test
+    void nl2sqlAgent_repairOnce_thenSuccess() throws Exception {
+        AiAssistService spy = org.mockito.Mockito.spy(service);
+        when(hiveConfig.isHiveAvailable()).thenReturn(true);
+
+        Connection conn = mock(Connection.class);
+        Statement stmt = mock(Statement.class);
+        ResultSet rs = mock(ResultSet.class);
+        when(hiveConfig.getConnection()).thenReturn(conn);
+        when(conn.createStatement()).thenReturn(stmt);
+        when(stmt.executeQuery(anyString()))
+                .thenThrow(new SQLException("bad column"))
+                .thenReturn(rs);
+        when(rs.next()).thenReturn(false);
+
+        doReturn("```sql\nselect bad_col from dwd_user\n```")
+                .doReturn("```sql\nselect id from dwd_user\n```")
+                .when(spy).chat(anyString(), anyString());
+
+        Map<String, Object> result = spy.nl2sqlAgent("查询用户ID", "table dwd_user(id string)");
+
+        assertEquals("success", result.get("status"));
+        assertEquals(2, result.get("attempts"));
+        assertEquals("select id from dwd_user LIMIT 100", result.get("sql"));
+    }
+
+    @Test
+    void nl2sqlAgent_nonSelect_returnsFailedImmediately() {
+        AiAssistService spy = org.mockito.Mockito.spy(service);
+        when(hiveConfig.isHiveAvailable()).thenReturn(false);
+        doReturn("```sql\ndelete from dwd_user\n```").when(spy).chat(anyString(), anyString());
+
+        Map<String, Object> result = spy.nl2sqlAgent("删数据", "");
+
+        assertEquals("failed", result.get("status"));
+        assertEquals(1, result.get("attempts"));
+        assertNull(result.get("sql"));
+        assertTrue(String.valueOf(result.get("error")).contains("仅允许 SELECT"));
+    }
+}


### PR DESCRIPTION
## 变更内容
- 新增 `AiAssistService.nl2sqlAgent`，实现 NL2SQL Agent 编排：Schema 上下文、SQL 安全守卫、Hive dry-run、失败修复回路（最多 2 轮）。
- 调整 `/api/ai/nl2sql` 接口返回结构，直接返回 agent 结果（包含 `status/attempts/sql/error/trace`）。
- 补充 `AiAssistServiceTest` 用例，覆盖 guard、非 select 拒绝、无 Hive 场景、修复回路场景。
- 修正 `MetadataControllerTest` 中与当前控制器实现不一致的 mock 依赖。

## 测试
- `podman run --rm -v /home/lyjdev/.m2:/root/.m2 -v /home/lyjdev/projects/datanote-repo:/workspace -w /workspace docker.m.daocloud.io/library/maven:3.9.9-eclipse-temurin-8 mvn test`
- 结果：`Tests run: 81, Failures: 0, Errors: 0, Skipped: 0`

## 说明
- 本 PR 不包含 `docs/` 目录变更。
